### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/bndry-co/protoc-gen-go-aip-test/security/code-scanning/1](https://github.com/bndry-co/protoc-gen-go-aip-test/security/code-scanning/1)

The fix involves adding a `permissions` block with the minimal necessary permissions to the workflow or to the relevant job. Since the workflow only shows a `make` job, and its steps are limited to setup and the `make` command (which do not require any write actions on the repository or PRs/issues), the most restrictive permissions can be applied—usually read-only access to repository contents. You can do this by adding the following block at the top workflow level (after the `name:` entry and before `on:`), or at the job level under `make:`. For this workflow, it's most typical and simplest to add it at the top, so all future jobs inherit the restriction.  
The edit is thus: After the `name: ci` line (before `on:`), add:

```yaml
permissions:
  contents: read
```

No other methods, imports, or variable definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
