### PR TITLE
fix: resolve code scanning alerts – add permissions to workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   make:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 6 * * *' # Daily at 6 AM UTC
   workflow_dispatch: # Allow manual trigger
 
+permissions: {}
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -69,7 +71,7 @@ jobs:
           git reset --hard HEAD || true
           
           if [ "${{ steps.rebase.outputs.rebase_success }}" != "true" ]; then
-            echo "❌ UPSTREAM SYNC FAILED: Rebase conflicts detected"
+            echo "\u274c UPSTREAM SYNC FAILED: Rebase conflicts detected"
             echo ""
             echo "Manual steps required:"
             echo "1. git checkout connectrpc"
@@ -79,7 +81,7 @@ jobs:
             echo "5. git push origin connectrpc --force-with-lease"
             exit 1
           elif [ "${{ steps.ci_checks.outputs.ci_success }}" != "true" ]; then
-            echo "❌ UPSTREAM SYNC FAILED: CI checks failed after rebase"
+            echo "\u274c UPSTREAM SYNC FAILED: CI checks failed after rebase"
             echo ""
             echo "Manual steps required:"
             echo "1. git checkout connectrpc"
@@ -88,5 +90,3 @@ jobs:
             echo "4. git push origin connectrpc --force-with-lease"
             exit 1
           fi
-      
-


### PR DESCRIPTION
## Summary

Fixes GitHub code scanning alert(s) about missing `permissions` blocks in GitHub Actions workflow files.

- **`ci.yml`** – Adds `permissions: contents: read` at the workflow level (fixes [code scanning alert #1](https://github.com/bndry-co/protoc-gen-go-aip-test/security/code-scanning/1): _Workflow does not contain permissions_)
- **`sync-upstream.yml`** – Adds `permissions: {}` at the workflow level; the existing job-level `permissions` block (`contents: write`, `pull-requests: write`) is preserved and continues to apply to the `sync` job

## Why

Without a top-level `permissions` key, GitHub Actions grants the GITHUB_TOKEN the repository's default permissions (often `write-all`). Explicitly setting the workflow-level permissions to the minimum required prevents a compromised action or step from gaining unintended write access.

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm code scanning alert #1 is resolved after merge